### PR TITLE
List dependencies setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,75 @@
+# Always prefer setuptools over distutils
+from setuptools import setup, find_packages
+# To use a consistent encoding
+from codecs import open
+from os import path
+
+here = path.abspath(path.dirname(__file__))
+
+# Get the long description from the README file
+with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
+setup(
+    name='usosapi',
+
+    # Versions should comply with PEP440.  For a discussion on single-sourcing
+    # the version across setup.py and the project code, see
+    # https://packaging.python.org/en/latest/single_source_version.html
+    version='1.0.0',
+
+    description='Simple helper module for interacting with USOS API.',
+    long_description=long_description,
+
+    # The project's main homepage.
+    url='https://github.com/MUCI/usosapi-python',
+
+    # Author details
+    author='USOS Developers',
+    author_email='usos@usos.edu.pl',
+
+    # Choose your license
+    license='MIT',
+
+    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[
+        # How mature is this project? Common values are
+        #   3 - Alpha
+        #   4 - Beta
+        #   5 - Production/Stable
+        'Development Status :: 3 - Beta',
+
+        # Indicate who your project is intended for
+        'Intended Audience :: Developers',
+
+        # Pick your license as you wish (should match "license" above)
+        'License :: OSI Approved :: MIT License',
+
+        # Specify the Python versions you support here. In particular, ensure
+        # that you indicate whether you support Python 2, Python 3 or both.
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+    ],
+
+    # What does your project relate to?
+    keywords='usos api usosapi',
+
+    # You can just specify the packages manually here if your project is
+    # simple. Or you can use find_packages().
+    # packages=find_packages(exclude=['contrib', 'docs', 'tests']),
+
+    # Alternatively, if you want to distribute just a my_module.py, uncomment
+    # this:
+    py_modules=["usosapi"],
+
+    # List run-time dependencies here.  These will be installed by pip when
+    # your project is installed. For an analysis of "install_requires" vs pip's
+    # requirements files see:
+    # https://packaging.python.org/en/latest/requirements.html
+    install_requires=[
+        'rauth',
+        'requests',
+    ],
+)


### PR DESCRIPTION
Listing dependencies in setup.py makes it easier to install the module. One could simply clone the repo and then execute `pip install -e usoswebapi-python`.
It would be great if you could [upload the module to PyPI](https://python-packaging-user-guide.readthedocs.org/en/latest/distributing/#uploading-your-project-to-pypi) :).
