### PR TITLE
Added MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Międzyuni­wer­sy­tec­kie Centrum Informatyzacji 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Added MIT license to open-source the library. On the USOS api website it says:
 "However, there are some unofficial libraries you might want to use. Many of those are currently maintained by members of the USOS Team, but we do not guarantee that all of these projects will stay alive:"[usosapi-python](https://github.com/MUCI/usosapi-python) - simple Python 3 module for desktop applications. It may help with the authorization process."
 
 Which indicates that the library is open for use, and that its use is actively encouraged. Yet, currently due to the lack of a license all rights are reserved and the use of it is forbidden, according to GitHub policy.
 
 Added MIT license with rights accredited to Międzyuniwersyteckie Centrum Informatyzacji.